### PR TITLE
Fixing notifications loading issue

### DIFF
--- a/src/components/models/FriendsList.vue
+++ b/src/components/models/FriendsList.vue
@@ -423,7 +423,11 @@
             getNotifications() {
                 this.$store.dispatch("getNotifications").then(response => {
                     this.notifications.unread_count = response.data.result.unread_count;
-                    this.notifications.data = response.data.result.notifications;
+                    let notifications = response.data.result.notifications;
+                    notifications.forEach((notif, index) => {
+                        notifications[index].data = JSON.parse(notif.data);
+                    });
+                    this.notifications.data = notifications;
                 }).catch(console.log);
             }
         },

--- a/src/components/models/Notification.vue
+++ b/src/components/models/Notification.vue
@@ -1,8 +1,10 @@
 <template>
 
-    <div v-if="notification.loaded">
-        <FriendRequest :notification="notification" v-if="notification.type === 1" />
-        <TheaterInvite :notification="notification" v-if="notification.type === 2" />
+    <div>
+        <FriendRequest :notification="notification" 
+            v-if="notification.type === 1" />
+        <TheaterInvite :notification="notification" 
+            v-if="notification.type === 2" />
     </div>
 
 </template>

--- a/src/components/models/NotificationCenter.vue
+++ b/src/components/models/NotificationCenter.vue
@@ -18,7 +18,7 @@
                 <span class="text-left">Notifications</span>
             </div>
 
-            <div class="notifications" v-if="!loading && notifications.data.length > 0">
+            <div class="notifications" v-if="notifications.data.length > 0">
 
                 <div class="notification"
                      :key="notification.id"
@@ -31,11 +31,9 @@
 
             </div>
 
-            <div class="no-notifications" v-if="!loading && notifications.data.length === 0">
+            <div class="no-notifications" v-if="notifications.data.length === 0">
                 You have no notifications yet!
             </div>
-
-            <vue-loaders-ball-beat class="notification-spinner" v-if="loading" />
 
         </div>
 
@@ -115,8 +113,6 @@
         data() {
             return {
                 opened: false,
-                loading: true,
-                loaded_once: false,
             }
         },
         directives: {
@@ -126,48 +122,11 @@
             Notification,
         },
         methods: {
-            loadNotification() {
-                if (this.notifications.data.length === 0){
-                    this.loading = false;
-                    this.loaded_once = true;
-                } else {
-                    this.notifications.data.forEach(async (_, index) => {
-                        if (!this.notifications.data[index].hasOwnProperty("read")){
-                            this.notifications.data[index].read = false;
-                        }
-                        if (!this.notifications.data[index].hasOwnProperty("accepted")){
-                            this.notifications.data[index].accepted = false;
-                        }
-                        if (!this.notifications.data[index].hasOwnProperty("loaded")){
-                            this.notifications.data[index].loaded = false;
-                        }
-                        if (this.notifications.data[index].type === 1) {
-                            await this.$store.dispatch("getFriendRequest", this.notifications.data[index].extra).then(response => {
-                                this.notifications.data[index].accepted = response.data.result.accepted;
-                                this.notifications.data[index].loaded = true;
-                            }).catch(() => {
-                                // this.notifications.data.splice(1, index);
-                            });
-                        } else if(this.notifications.data[index].type === 2) {
-                            await this.$store.dispatch("getTheater", this.notifications.data[index].extra).then(response => {
-                                this.notifications.data[index].theater = response.data.result;
-                                this.notifications.data[index].loaded = true;
-                            }).catch(() => {
-                                // this.notifications.data.splice(1, index);
-                            });
-                        }
-                        if (index === (this.notifications.data.length - 1)){
-                            this.loading = false;
-                            this.loaded_once = true;
-                        }
-                    });
-                }
-            },
             toggle() {
                 this.opened = !this.opened;
-                if (!this.loaded_once){
-                    this.loadNotification();
-                }
+                setInterval(() => {
+                    this.notifications.unread_count = 0;
+                }, 1000);
             },
             close() {
                 this.opened = false;

--- a/src/components/models/notifications/FriendRequest.vue
+++ b/src/components/models/notifications/FriendRequest.vue
@@ -2,9 +2,7 @@
 
     <div class="friend-invite">
 
-        <img :src="apiBaseUrl + '/uploads/avatars/' + notification.from_user.avatar + '.png'"
-             class="avatar"
-             :alt="notification.from_user.fullname" />
+        <img :src="apiBaseUrl + '/uploads/avatars/' + notification.from_user.avatar + '.png'" class="avatar" :alt="notification.from_user.fullname" />
 
         <div class="notification-details">
 
@@ -16,9 +14,8 @@
             </div>
 
             <VueLoadingButton class="nc-button nc-btn-accept-fr"
-                              v-if="!notification.accepted"
-                              :loading="loading"
-                              @click.native="acceptFriendRequest($event, notification.extra)">
+                              v-if="!notification.data.accepted"
+                              @click.native="acceptFriendRequest($event, notification.data.id)">
                 Accept
             </VueLoadingButton>
 
@@ -97,7 +94,8 @@
                             title: "Success",
                             duration: 2000,
                         });
-                        this.notification.accepted = true;
+                        this.$parent.$parent.close();
+                        this.notification.data.accepted = true;
                         this.loading = false;
                     }).catch(() => {
                         this.$notify({

--- a/src/components/models/notifications/TheaterInvite.vue
+++ b/src/components/models/notifications/TheaterInvite.vue
@@ -2,9 +2,7 @@
 
     <div class="theater-invite">
 
-        <img :src="apiBaseUrl + '/uploads/avatars/' + notification.from_user.avatar + '.png'"
-             class="avatar"
-             :alt="notification.from_user.fullname" />
+        <img :src="apiBaseUrl + '/uploads/avatars/' + notification.from_user.avatar + '.png'" class="avatar" :alt="notification.from_user.fullname" />
 
         <div class="notification-details">
             <div class="notification-title">
@@ -15,19 +13,20 @@
             </div>
             <div class="nc-th">
                 <div class="theater-image">
-                    <div class="default-nc-poster" v-if="notification.theater.movie.poster === 'default'">
+                    <div class="default-nc-poster" v-if="notification.data.movie.poster === 'default'">
                         <i class="poster icofont-file-mov"></i>
                     </div>
                     <img v-else
-                         :src="apiBaseUrl + '/uploads/posters/' + notification.theater.movie.poster + '.png'"
+                         :src="apiBaseUrl + '/uploads/posters/' + notification.data.movie.poster + '.png'"
                          alt="Poster" />
                 </div>
                 <div class="th-details">
                     <span class="th-name">
-                        {{ notification.theater.title }}
+                        {{ notification.data.title }}
                     </span>
                 </div>
-                <button class="nc-button nc-btn-join-th" @click="joinTheater(notification.theater)">
+                <button class="nc-button nc-btn-join-th" 
+                    @click="joinTheater(notification.data)">
                     Join <i class="icofont-plus"></i>
                 </button>
             </div>


### PR DESCRIPTION
Before this commit, NotificationCenter was requesting for each notifications to load but now with this change, notifications will load in one request.

Related commit in other services:

gRPC.server commits: <br/> https://github.com/CastyLab/grpc.server/commit/b8c3a37e0504c12d3310e51a59e99bcd411c9e88
https://github.com/CastyLab/grpc.server/commit/104cbf4ebc42cc0a0354e4c3df44f8176ce44d17
https://github.com/CastyLab/grpc.server/commit/807311e1251e87c9ff62f43b2f251f2430a7868c

gRPC.proto commits:
https://github.com/CastyLab/grpc.proto/commit/c2d398772cecae88b6d4f8a18058a1ae1852be14